### PR TITLE
Update to GNOME 46 Runtime

### DIFF
--- a/org.gnome.TwentyFortyEight.json
+++ b/org.gnome.TwentyFortyEight.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.TwentyFortyEight",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-2048",
     "finish-args": [


### PR DESCRIPTION
Closes #9.