### PR TITLE
Update runtime to GNOME 48

### DIFF
--- a/org.gnome.TwentyFortyEight.json
+++ b/org.gnome.TwentyFortyEight.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.TwentyFortyEight",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-2048",
     "finish-args": [


### PR DESCRIPTION
GNOME 46 is now deprecated. Until it is updated, GNOME Software will claim it has "Stopped Receiving Updates".