### PR TITLE
Update runtime to 50

### DIFF
--- a/org.gnome.TwentyFortyEight.json
+++ b/org.gnome.TwentyFortyEight.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.TwentyFortyEight",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-2048",
     "finish-args": [
@@ -13,11 +13,8 @@
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/share/aclocal",
-        "/man",
         "/share/man",
-        "/share/gtk-doc",
+        "/share/vala",
         "*.la",
         "*.a"
     ],


### PR DESCRIPTION
- Update runtime to 50

### Error message

```
Thread 1 "gnome-2048" received signal SIGSEGV, Segmentation fault.
_clutter_actor_handle_event (self=<optimized out>, event=0x555555df2e10) at clutter-actor.c:20547
20547	      ClutterActor *parent = iter->priv->parent;

-------

(gdb) bt

#0  _clutter_actor_handle_event (self=<optimized out>, event=0x555555df2e10) at clutter-actor.c:20547
#1  0x00007ffff6fd6177 in emit_event_chain (event=<optimized out>) at clutter-main.c:2040
#2  emit_pointer_event (event=<optimized out>, device=<optimized out>) at clutter-main.c:2063
#3  _clutter_process_event_details
    (stage=<optimized out>, context=<error reading variable: Cannot access memory at address 0x7fffffffcfa0>, event=<error reading variable: Cannot access memory at address 0x7fffffffcf98>) at clutter-main.c:2413
#4  _clutter_process_event (event=<error reading variable: Cannot access memory at address 0x7fffffffcf98>, event@entry=0x555555df2e10) at clutter-main.c:2573
#5  0x00007ffff6fee7a8 in _clutter_stage_process_queued_events (stage=0x555555b08380) at clutter-stage.c:1031

-------

(gdb) bt full

#0  _clutter_actor_handle_event (self=<optimized out>, event=0x555555df2e10) at clutter-actor.c:20547
        parent = <optimized out>
        event_tree = 0x555556440d90
        iter = 0x993c49c5932ecb00
        is_key_event = <optimized out>
        i = 0
#1  0x00007ffff6fd6177 in emit_event_chain (event=<optimized out>) at clutter-main.c:2040
        lock = Python Exception <class 'gdb.MemoryError'>: Cannot access memory at address 0x7ffff709e3cc
#2  emit_pointer_event (event=<optimized out>, device=<optimized out>) at clutter-main.c:2063
        context = <optimized out>
#3  _clutter_process_event_details
    (stage=<optimized out>, context=<error reading variable: Cannot access memory at address 0x7fffffffcfa0>, event=<error reading variable: Cannot access memory at address 0x7fffffffcf98>) at clutter-main.c:2413
        actor = <optimized out>
        x = 3.06736162e+13
        y = 3.0611365e-41
Python Exception <class 'gdb.MemoryError'>: Cannot access memory at address 0x7fffffffcfb8
#4  _clutter_process_event (event=<error reading variable: Cannot access memory at address 0x7fffffffcf98>, event@entry=0x555555df2e10) at clutter-main.c:2573
Python Exception <class 'gdb.MemoryError'>: Cannot access memory at address 0x7fffffffcfa0
#5  0x00007ffff6fee7a8 in _clutter_stage_process_queued_events (stage=0x555555b08380) at clutter-stage.c:1031
        next_event = <optimized out>
        device = <optimized out>
        event = 0x555555df2e10
        next_device = <optimized out>
        check_device = <optimized out>
        priv = 0x555555b07d80
        events = Python Exception <class 'gdb.MemoryError'>: Cannot access memory at address 0x7fffffffd040
```
